### PR TITLE
Update zh_cn.json

### DIFF
--- a/src/main/resources/assets/endermail/lang/zh_cn.json
+++ b/src/main/resources/assets/endermail/lang/zh_cn.json
@@ -1,6 +1,6 @@
 {
     "_comment": "Ender Mail Language File",
-    "_comment": "English - UNITED STATES",
+    "_comment": "Chinese(Simplified) - China Mainland",
 
     "_comment": "BLOCKS",
     "block.endermail.package": "包裹",
@@ -9,7 +9,7 @@
     "_comment": "ITEMS",
     "item.endermail.package_controller": "包裹控制器",
     "item.endermail.packing_tape": "包装胶带",
-    "item.endermail.stamp": "邮件",
+    "item.endermail.stamp": "邮票",
 
     "_comment": "STRINGS",
     "string.endermail.cancel": "取消",


### PR DESCRIPTION
I typed '邮票' (which means stamp) as '邮件' (which means mail) by mistake.
-     "item.endermail.stamp": "邮件",
-     "item.endermail.stamp": "邮票",

Commit From Repo:gepsieh/EnderMail Branch:gepsieh-patch-1