### PR TITLE
Do not set the TE after changing to a different state of the same block

### DIFF
--- a/src/main/java/com/chaosthedude/endermail/blocks/LockerBlock.java
+++ b/src/main/java/com/chaosthedude/endermail/blocks/LockerBlock.java
@@ -125,15 +125,8 @@ public class LockerBlock extends ContainerBlock {
 	public static void setFilled(boolean filled, World world, BlockPos pos) {
 		BlockState state = world.getBlockState(pos);
 		if (state.getBlock() == EnderMailBlocks.LOCKER) {
-			if ((state.get(FILLED) && !filled) || (!state.get(FILLED) && filled)) {
-				TileEntity tileentity = world.getTileEntity(pos);
-				world.setBlockState(pos,
-						EnderMailBlocks.LOCKER.getDefaultState().with(FACING, state.get(FACING)).with(FILLED, filled),
-						3);
-				if (tileentity != null) {
-					tileentity.validate();
-					world.setTileEntity(pos, tileentity);
-				}
+			if (state.get(FILLED) != filled) {
+				world.setBlockState(pos, state.with(FILLED, filled), 3);
 			}
 		}
 	}

--- a/src/main/java/com/chaosthedude/endermail/blocks/PackageBlock.java
+++ b/src/main/java/com/chaosthedude/endermail/blocks/PackageBlock.java
@@ -287,13 +287,8 @@ public class PackageBlock extends ContainerBlock {
 	}
 
 	public static void setState(boolean stamped, World world, BlockPos pos) {
-		BlockState iblockstate = world.getBlockState(pos);
-		TileEntity tileentity = world.getTileEntity(pos);
-		world.setBlockState(pos, EnderMailBlocks.PACKAGE.getDefaultState().with(FACING, iblockstate.get(FACING)).with(STAMPED, stamped), 3);
-		if (tileentity != null) {
-			tileentity.validate();
-			world.setTileEntity(pos, tileentity);
-		}
+		BlockState state = world.getBlockState(pos);
+		world.setBlockState(pos, state.with(STAMPED, stamped), 3);
 	}
 
 }


### PR DESCRIPTION
I assume you needed this in some previous MC version, but it isn't necessary any more (TEs persist through replacing a block with a different state of the same block).

Fixes #40 and MaxNeedsSnacks/RoadRunner#34